### PR TITLE
Fix deprecation/whitespace warnings

### DIFF
--- a/src/Formatting.jl
+++ b/src/Formatting.jl
@@ -7,6 +7,7 @@ module Formatting
         printfmt, printfmtln, fmt, format,
         sprintf1, generate_formatter
 
+    using Compat
 
     include("cformat.jl" )
     include("fmtspec.jl")

--- a/src/cformat.jl
+++ b/src/cformat.jl
@@ -6,12 +6,16 @@ function sprintf1( fmt::ASCIIString, x )
     f( x )
 end
 
+if VERSION < v"0.4-"
+    const base64encode = base64
+end
+
 function generate_formatter( fmt::ASCIIString )
     global formatters
     if haskey( formatters, fmt )
         return formatters[fmt]
     end
-    func = symbol( "sprintf_" * replace( base64( fmt ), "=", "!" ) )
+    func = symbol( "sprintf_" * replace( base64encode( fmt ), "=", "!" ) )
 
     if !contains( fmt, "'" )
         test = Base.Printf.parse( fmt )
@@ -180,7 +184,7 @@ function format{T<:Real}( x::T;
     fractional = 0
     if T <: Rational && mixedfraction
         actualconv = "d"
-        actualx = int( trunc( x ) )
+        actualx = trunc( Int, x )
         fractional = abs(x) - abs(actualx)
     else
         if parens && !in( actualconv[1], "xX" )

--- a/src/fmtcore.jl
+++ b/src/fmtcore.jl
@@ -57,11 +57,11 @@ _ipre(::Union(_Hex, _HEX)) = "0x"
 _ipre(::_Oct) = "0o"
 _ipre(::_Bin) = "0b"
 
-_digitchar(x::Integer, ::_Bin) = char(x == 0 ? '0' : '1')
-_digitchar(x::Integer, ::_Dec) = char('0' + x)
-_digitchar(x::Integer, ::_Oct) = char('0' + x)
-_digitchar(x::Integer, ::_Hex) = char(x < 10 ? '0' + x : 'a' + (x - 10))
-_digitchar(x::Integer, ::_HEX) = char(x < 10 ? '0' + x : 'A' + (x - 10))
+_digitchar(x::Integer, ::_Bin) = @compat Char(x == 0 ? '0' : '1')
+_digitchar(x::Integer, ::_Dec) = @compat Char('0' + x)
+_digitchar(x::Integer, ::_Oct) = @compat Char('0' + x)
+_digitchar(x::Integer, ::_Hex) = @compat Char(x < 10 ? '0' + x : 'a' + (x - 10))
+_digitchar(x::Integer, ::_HEX) = @compat Char(x < 10 ? '0' + x : 'A' + (x - 10))
 
 _signchar(x::Number, s::Char) = x < 0 ? '-' :
                                 s == '+' ? '+' :
@@ -158,7 +158,7 @@ function _pfmt_float(out::IO, sch::Char, zs::Integer, intv::Real, decv::Real, pr
     write(out, '.')
     # print decimal part
     if prec > 0
-        idecv = iround(decv * exp10(prec))
+        idecv = round(Integer, decv * exp10(prec))
         nd = _ndigits(idecv, _Dec())
         if nd < prec
             _repwrite(out, '0', prec - nd)
@@ -171,14 +171,14 @@ function _pfmt_f(out::IO, fs::FormatSpec, x::FloatingPoint)
     # separate sign, integer, and decimal part
     ax = abs(x)
     sch = _signchar(x, fs.sign)
-    intv = itrunc(ax)
+    intv = trunc(Integer, ax)
     decv = ax - intv
 
     # calculate length
     xlen = _ndigits(intv, _Dec()) + 1 + fs.prec
     if sch != '\0'
         xlen += 1
-    end 
+    end
 
     # print
     wid = fs.width
@@ -199,7 +199,7 @@ function _pfmt_f(out::IO, fs::FormatSpec, x::FloatingPoint)
 end
 
 function _pfmt_floate(out::IO, sch::Char, zs::Integer, u::Real, prec::Int, e::Int, ec::Char)
-    intv = itrunc(u)
+    intv = trunc(Integer,u)
     decv = u - intv
     _pfmt_float(out, sch, zs, intv, decv, prec)
     write(out, ec)
@@ -210,8 +210,8 @@ function _pfmt_floate(out::IO, sch::Char, zs::Integer, u::Real, prec::Int, e::In
         e = -e
     end
     (e1, e2) = divrem(e, 10)
-    write(out, char('0' + e1))
-    write(out, char('0' + e2))
+    write(out, @compat Char('0' + e1))
+    write(out, @compat Char('0' + e2))
 end
 
 
@@ -223,7 +223,7 @@ function _pfmt_e(out::IO, fs::FormatSpec, x::FloatingPoint)
         e = 0
         u = zero(x)
     else
-        e = ifloor(log10(ax))  # exponent
+        e = floor(Integer,log10(ax))  # exponent
         u = ax / exp10(e)  # significand
     end
 

--- a/src/fmtspec.jl
+++ b/src/fmtspec.jl
@@ -17,9 +17,9 @@
 
 ## FormatSpec type
 
-const _numtypchars = Set('b', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 'x', 'X')
+const _numtypchars = Set(['b', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 'x', 'X'])
 
-_tycls(c::Char) = 
+_tycls(c::Char) =
     (c == 'd' || c == 'n' || c == 'b' || c == 'o' || c == 'x') ? 'i' :
     (c == 'e' || c == 'f' || c == 'g') ? 'f' :
     (c == 'c') ? 'c' :
@@ -29,7 +29,7 @@ _tycls(c::Char) =
 immutable FormatSpec
     cls::Char    # category: 'i' | 'f' | 'c' | 's'
     typ::Char
-    fill::Char    
+    fill::Char
     align::Char
     sign::Char
     width::Int
@@ -121,10 +121,10 @@ function FormatSpec(s::String)
             if a4[1] == '0'
                 _zpad = true
                 if length(a4) > 1
-                    _width = int(a4[2:end])
+                    _width = parseint(Int,a4[2:end])
                 end
             else
-                _width = int(a4)
+                _width = parseint(Int,a4)
             end
         end
 
@@ -135,7 +135,7 @@ function FormatSpec(s::String)
 
         # a6 [.prec]
         if a6 != nothing
-            _prec = int(a6[2:end])
+            _prec = parseint(Int,a6[2:end])
         end
 
         # a7: [type]
@@ -145,7 +145,7 @@ function FormatSpec(s::String)
     end
 
     return FormatSpec(_typ;
-                      fill=_fill, 
+                      fill=_fill,
                       align=_align,
                       sign=_sign,
                       width=_width,
@@ -172,12 +172,12 @@ function printfmt(io::IO, fs::FormatSpec, x)
     cls = fs.cls
     ty = fs.typ
     if cls == 'i'
-        ix = integer(x)
+        ix = @compat Integer(x)
         ty == 'd' || ty == 'n' ? _pfmt_i(io, fs, ix, _Dec()) :
         ty == 'x' ? _pfmt_i(io, fs, ix, _Hex()) :
         ty == 'X' ? _pfmt_i(io, fs, ix, _HEX()) :
         ty == 'o' ? _pfmt_i(io, fs, ix, _Oct()) :
-        _pfmt_i(io, fs, ix, _Bin())  
+        _pfmt_i(io, fs, ix, _Bin())
     elseif cls == 'f'
         fx = float(x)
         if isfinite(fx)
@@ -190,7 +190,7 @@ function printfmt(io::IO, fs::FormatSpec, x)
     elseif cls == 's'
         _pfmt_s(io, fs, _srepr(x))
     else # cls == 'c'
-        _pfmt_s(io, fs, char(x))
+        _pfmt_s(io, fs, @compat Char(x))
     end
 end
 
@@ -198,6 +198,3 @@ printfmt(fs::FormatSpec, x) = printfmt(STDOUT, fs, x)
 
 fmt(fs::FormatSpec, x) = (buf = IOBuffer(); printfmt(buf, fs, x); bytestring(buf))
 fmt(spec::String, x) = fmt(FormatSpec(spec), x)
-
-
- 

--- a/src/formatexpr.jl
+++ b/src/formatexpr.jl
@@ -28,12 +28,12 @@ function make_argspec(s::String, pos::Int)
     if !isempty(s)
         ifil = searchindex(s, "|>")
         if ifil == 0
-            iarg = int(s)
+            iarg = parseint(Int,s)
         else
-            iarg = ifil > 1 ? int(s[1:ifil-1]) : -1
+            iarg = ifil > 1 ? parseint(Int,s[1:ifil-1]) : -1
             hasfil = true
             ff = eval(symbol(s[ifil+2:end]))
-        end       
+        end
     end
 
     if pos > 0

--- a/test/cformat.jl
+++ b/test/cformat.jl
@@ -23,7 +23,7 @@ function test_equality()
         l.args[2].args[2] = Expr( :macrocall, symbol( "@sprintf" ), fmt, :x )
         mfmtr = eval( l )
         for i in 1:10000
-            j = int( erfinv( rand() * 1.99 - 1.99/2.0 ) * 100000 )
+            j = round(Int, erfinv( rand() * 1.99 - 1.99/2.0 ) * 100000 )
             expect = mfmtr( j )
             actual = sprintf1( fmt, j )
             @test expect == actual


### PR DESCRIPTION
Just a few things that were exposed by TermWin (/ subsequently running the Formatting test suite). 